### PR TITLE
fix(guess_voice): 修复了获取角色语音时，如用户指定语言（"原神语音 日 七七"），截取到的角色名（" 七七"）未排除空格分隔符的问题。

### DIFF
--- a/Guess_voice/__init__.py
+++ b/Guess_voice/__init__.py
@@ -114,6 +114,7 @@ async def get_genshin_voice(bot: Bot, event: Union[GroupMessageEvent, PrivateMes
     else:
         language = '中'
         name = name.replace('中', '')
+    name = name.strip()
     await download_voice(bot, event)
     path = await get_random_voice(name, language)
     if not path:


### PR DESCRIPTION
此bug会导致无法获取到指定语言的角色语音。