### PR TITLE
fix(guess_voice): 修复了“原神猜语音”中，当角色无别名时，错误的正则表达式（如：早柚|）会导致匹配任意字符串的问题

### DIFF
--- a/Guess_voice/handler.py
+++ b/Guess_voice/handler.py
@@ -63,7 +63,8 @@ def create_guess_matcher(role_name, second, group_id):
         return False
 
     alias_list = character_json.get(role_name, [])
-    re_str = role_name + '|' + '|'.join(alias_list)
+    alias_list.insert(0, role_name)
+    re_str = '|'.join(alias_list)
     guess_matcher = on_regex(re_str, temp=True, rule=Rule(check_group))
     guess_matcher.plugin_name = "Guess_voice"
 


### PR DESCRIPTION
修复后，无别名角色的正则表达式为“早柚”。