### PR TITLE
网页截图增加full_page配置项

### DIFF
--- a/LittlePaimon/utils/brower.py
+++ b/LittlePaimon/utils/brower.py
@@ -152,9 +152,9 @@ class AsyncPlaywright:
             else:
                 card = page
             if path:
-                img = await card.screenshot(path=path, timeout=timeout)
+                img = await card.screenshot(path=path, timeout=timeout, full_page=True)
             else:
-                img = await card.screenshot(timeout=timeout)
+                img = await card.screenshot(timeout=timeout, full_page=True)
             return MessageSegment.image(img)
         except Exception as e:
             logger.warning(f"Playwright 截图 url：{url} element：{element} 发生错误 {type(e)}：{e}")

--- a/LittlePaimon/utils/brower.py
+++ b/LittlePaimon/utils/brower.py
@@ -152,9 +152,9 @@ class AsyncPlaywright:
             else:
                 card = page
             if path:
-                img = await card.screenshot(path=path, timeout=timeout, full_page=True)
+                img = await card.screenshot(path=path, timeout=timeout, full_page=False)
             else:
-                img = await card.screenshot(timeout=timeout, full_page=True)
+                img = await card.screenshot(timeout=timeout, full_page=False)
             return MessageSegment.image(img)
         except Exception as e:
             logger.warning(f"Playwright 截图 url：{url} element：{element} 发生错误 {type(e)}：{e}")


### PR DESCRIPTION
增加full_page配置项，修改[brower.py](https://github.com/CMHopeSunshine/LittlePaimon/commit/7d0de51fe64ac8d8017f0b9c1a98567acdb92efc)源码中的full_page=False为full_page=True即可获取完整可滚动页面的屏幕截图，而不是当前可见的视口。