### PR TITLE
build: 更换底层镜像

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM python:slim
+FROM python:3-slim-bullseye
 
 RUN pip3 --no-cache-dir install nb-cli
 


### PR DESCRIPTION
`python:slim` 今天从 `3-slim-bullseye` 变更到了 `3-slim-bookworm`，playwright 无法在此镜像安装

此外，[release_docker](https://github.com/CMHopeSunshine/LittlePaimon/blob/Bot/.github/workflows/release_docker.yaml) Action 打包镜像时会使用 git tag 作为镜像标签推送，使用手动构建 `workflow_dispatch` 可能导致推送镜像失败

https://github.com/CMHopeSunshine/LittlePaimon/blob/57627f9272ba5feddf2e2f4575550ae8a831ebc5/.github/workflows/release_docker.yaml#L34

或许可以将其改为使用 commit hash 作为第二 tag 或者不推送 VERSION tag 镜像

```
echo VERSION=${URL}:$(git rev-parse --short "$GITHUB_SHA") >> $GITHUB_OUTPUT
```