### PR TITLE
🐛 去除原神武器图鉴链接多余的`/`和对星铁攻略/材料链接`空格`进行转义

### DIFF
--- a/LittlePaimon/plugins/Paimon_Wiki/wiki_api.py
+++ b/LittlePaimon/plugins/Paimon_Wiki/wiki_api.py
@@ -7,7 +7,7 @@ API: Dict[str, str] = {
     '角色材料': '{proxy}https://raw.githubusercontent.com/Nwflower/genshin-atlas/master/material%20for%20role/{name}.png',
     '收益曲线': '{proxy}https://raw.githubusercontent.com/CMHopeSunshine/LittlePaimonRes/main/genshin_guide/curve/{name}.jpg',
     '参考面板': '{proxy}https://raw.githubusercontent.com/CMHopeSunshine/LittlePaimonRes/main/genshin_guide/panel/{name}.jpg',
-    '武器图鉴': '{proxy}https://raw.githubusercontent.com/Nwflower/genshin-atlas/master/{name}',
+    '武器图鉴': '{proxy}https://raw.githubusercontent.com/Nwflower/genshin-atlas/master{name}',
     '圣遗物图鉴': '{proxy}https://raw.githubusercontent.com/Nwflower/genshin-atlas/master/artifact/{name}.png',
     '原魔图鉴': '{proxy}https://raw.githubusercontent.com/CMHopeSunshine/GenshinWikiMap/master/results/monster_map/{name}.jpg',
     '特产图鉴': '{proxy}https://raw.githubusercontent.com/Nwflower/genshin-atlas/master/specialty/{name}.png',

--- a/LittlePaimon/plugins/star_rail_wiki/__init__.py
+++ b/LittlePaimon/plugins/star_rail_wiki/__init__.py
@@ -105,7 +105,7 @@ async def sr_wiki_got(matcher: Matcher,
         final_name = str(matches[0])
         try:
             await wiki.finish(MessageSegment.image(
-                f'{config.github_proxy}https://raw.githubusercontent.com/Nwflower/star-rail-atlas/master{data[final_name]}'
+                f'{config.github_proxy}https://raw.githubusercontent.com/Nwflower/star-rail-atlas/master{data[final_name]}'.replace(" ", "%20")
             ))
         except ActionFailed:
             await wiki.finish(f'{final_name}的{type}发送失败，可能是网络问题')


### PR DESCRIPTION
虽然以普遍理性而言判断下武器图鉴name是否startswith(＂/＂)更好，不过花佬应该也不会随便改吧(

然后星铁攻略直接replace了，没用quote，感觉quote处理起来还麻烦点